### PR TITLE
Fixed beat grids drifting

### DIFF
--- a/src/ui/player/waveform.c
+++ b/src/ui/player/waveform.c
@@ -51,11 +51,29 @@ static int Waveform_Update(Component *base) {
   if (inWaveform) {
     float wheel = GetMouseWheelMove();
     if (wheel != 0.0f) {
-      r->State->ZoomScale -= wheel * 0.5f;
-      if (r->State->ZoomScale < 0.25f)
-        r->State->ZoomScale = 0.25f;
-      if (r->State->ZoomScale > 32.0f)
-        r->State->ZoomScale = 32.0f;
+      int currentIndex = 0;
+      float minDiff = 99999.0f;
+      for (int i = 0; i < NUM_ZOOM_LEVELS; i++) {
+        float diff = fabsf(r->State->ZoomScale - ZOOM_LEVELS[i]);
+        if (diff < minDiff) {
+          minDiff = diff;
+          currentIndex = i;
+        }
+      }
+
+      float deadZone = 0.05f;
+      // Use a small deadzone to ignore microscopic trackpad jitters
+      if (wheel > deadZone) {
+        currentIndex--; // Positive wheel decreases zoom
+      } else if (wheel < -deadZone) {
+        currentIndex++; // Negative wheel increases zoom
+      }
+
+      // Clamp the index
+      if (currentIndex < 0) currentIndex = 0;
+      if (currentIndex >= NUM_ZOOM_LEVELS) currentIndex = NUM_ZOOM_LEVELS - 1;
+
+      r->State->ZoomScale = ZOOM_LEVELS[currentIndex];
     }
   }
 
@@ -259,7 +277,12 @@ static void Waveform_Draw(Component *base) {
 
   Font faceXS = UIFonts_GetFace(S(8));
 
-  float effectiveZoom = (float)r->State->ZoomScale;
+  float pitchRatio = 1.0f + (r->State->TempoPercent / 100.0f);
+  
+  // Apply the pitch ratio to the zoom scale.
+  // Faster BPM (ratio > 1.0) increases effective zoom -> squishes waveform
+  // Slower BPM (ratio < 1.0) decreases effective zoom -> stretches waveform
+  float effectiveZoom = (float)r->State->ZoomScale * pitchRatio;
   if (effectiveZoom < 0.1f)
     effectiveZoom = 0.1f;
   double elapsedHalfFrames = r->State->Position;

--- a/src/ui/player/waveform.h
+++ b/src/ui/player/waveform.h
@@ -16,7 +16,11 @@ struct WaveformRenderer {
   float lastMouseX;
 };
 
-
+static const float ZOOM_LEVELS[] = {
+    0.25f, 0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 2.0f, 3.0f, 
+    4.0f, 6.0f, 8.0f, 12.0f, 16.0f, 24.0f, 32.0f
+};
+static const int NUM_ZOOM_LEVELS = sizeof(ZOOM_LEVELS) / sizeof(ZOOM_LEVELS[0]);
 
 void WaveformRenderer_Init(WaveformRenderer *r, int id, DeckState *state,
                            DeckState *otherDeck);


### PR DESCRIPTION
The tempo changes on the songs didn't affect the beat grids or the waveforms but in reality if you increase the bpm, the beat grids/waveforms should squish, if you decrease the bpm they should stretch. I added a modifier to the zoom level that adjusts the beat grid/waveform based on the tempo change. I also replaced previous mouse wheel logic to a one that snaps to the exact values to avoid drifting due to rounding errors.