### PR TITLE
Extended beatgrids for Rekordbox

### DIFF
--- a/src/library/rekordbox_reader.cpp
+++ b/src/library/rekordbox_reader.cpp
@@ -244,6 +244,7 @@ extern "C" void RB_FreeDatabase(RBDatabase* db) {
             if (db->Tracks[i].Cues) delete[] db->Tracks[i].Cues;
             if (db->Tracks[i].Phrases) delete[] db->Tracks[i].Phrases;
             if (db->Tracks[i].DynamicWaveform) delete[] db->Tracks[i].DynamicWaveform;
+            if (db->Tracks[i].BeatGrid) delete[] db->Tracks[i].BeatGrid;
         }
         delete[] db->Tracks;
     }
@@ -270,7 +271,10 @@ static void RB_ParseAnlz(const std::string& path, RBTrack* track) {
             if (tag == rekordbox_anlz_t::SECTION_TAGS_BEAT_GRID) {
                 auto bg = static_cast<rekordbox_anlz_t::beat_grid_tag_t*>(section->body());
                 track->BeatGridCount = bg->num_beats();
-                for (uint32_t i = 0; i < bg->num_beats() && i < 1024; i++) {
+
+                if (track->BeatGrid) delete[] track->BeatGrid;
+                track->BeatGrid = new RBBeat[track->BeatGridCount];
+                for (uint32_t i = 0; i < bg->num_beats(); i++) {
                     auto b = (*bg->beats())[i].get();
                     track->BeatGrid[i].Time = b->time();
                     track->BeatGrid[i].BPM = b->tempo();

--- a/src/library/rekordbox_reader.h
+++ b/src/library/rekordbox_reader.h
@@ -69,7 +69,7 @@ typedef struct {
     uint32_t CueCount;
     RBPhrase* Phrases;
     uint32_t PhraseCount;
-    RBBeat BeatGrid[1024];
+    RBBeat* BeatGrid;
     int BeatGridCount;
     unsigned char StaticWaveform[8192];
     int StaticWaveformLen;

--- a/src/ui/browser/browser.c
+++ b/src/ui/browser/browser.c
@@ -789,10 +789,13 @@ static int Browser_Update(Component *base) {
               newTrack->WaveformType = t->WaveformType;
 
               // Cues and Beats
-              newTrack->BeatGridCount =
-                  t->BeatGridCount > 1024 ? 1024 : t->BeatGridCount;
-              for (int i = 0; i < newTrack->BeatGridCount; i++)
-                newTrack->BeatGrid[i] = t->BeatGrid[i];
+              newTrack->BeatGridCount = t->BeatGridCount;
+              if (newTrack->BeatGridCount > 0) {
+                  newTrack->BeatGrid = (RBBeat*)malloc(sizeof(RBBeat) * newTrack->BeatGridCount);
+                  memcpy(newTrack->BeatGrid, t->BeatGrid, sizeof(RBBeat) * newTrack->BeatGridCount);
+              } else {
+                  newTrack->BeatGrid = NULL;
+              }
 
               for (uint32_t i = 0; i < t->CueCount && i < 32; i++) {
                 if (t->Cues[i].ID >= 1 && t->Cues[i].ID <= 8) {
@@ -812,8 +815,11 @@ static int Browser_Update(Component *base) {
 
               TrackState *oldTrack = targetDeck->LoadedTrack;
               targetDeck->LoadedTrack = newTrack;
-              if (oldTrack)
+              if (oldTrack){
+                if (oldTrack->BeatGrid != NULL) free(oldTrack->BeatGrid);
                 free(oldTrack);
+              }
+                
               targetDeck->PositionMs = (newTrack->CuesCount > 0)
                                            ? newTrack->Cues[0].Start
                                            : (newTrack->BeatGridCount > 0

--- a/src/ui/player/player_state.h
+++ b/src/ui/player/player_state.h
@@ -32,7 +32,7 @@ typedef struct {
 } WaveformSettings;
 
 typedef struct TrackState {
-  RBBeat BeatGrid[1024];
+  RBBeat* BeatGrid;
   unsigned int GridOffset;
   int BeatGridCount;
   unsigned char StaticWaveform[8192];

--- a/src/ui/player/waveform.c
+++ b/src/ui/player/waveform.c
@@ -506,7 +506,7 @@ static void Waveform_Draw(Component *base) {
   // Beat Grid — ticks use semi-transparent overlay to preserve waveform pixels
   // beneath
   if (r->State->LoadedTrack != NULL) {
-    for (int i = 0; i < 1024; i++) {
+    for (int i = 0; i < r->State->LoadedTrack->BeatGridCount; i++) {
       unsigned int originalMs = r->State->LoadedTrack->BeatGrid[i].Time;
       uint16_t beatNum = r->State->LoadedTrack->BeatGrid[i].BeatNumber;
       if (originalMs == 0xFFFFFFFF || originalMs == 0)


### PR DESCRIPTION
Number of beats for Rekordbox was limited to 1024 but long techno songs can easily exceed that so I changed the logic to use dynamic allocation so the beat grids can extend as far as the songs allow.